### PR TITLE
NEW: Python2.7 support

### DIFF
--- a/settings_vial/settings_vial.py
+++ b/settings_vial/settings_vial.py
@@ -6,6 +6,12 @@ from dotenv import dotenv_values
 
 from .exceptions import MissingOverrideKeysWarning, NotCallableWarning, UnsupportedSetTypeWarning
 
+try:
+    from json.decode import JSONDecodeError
+except ImportError:
+    # Python2.7 does not have this exception, it simply raises ValueError
+    JSONDecodeError = ValueError
+
 
 class Settings:
     r"""Settings from environment variables.
@@ -112,7 +118,7 @@ class Settings:
                 # surrounded with `{}`.
                 try:
                     json_value = json.loads(value)
-                except json.decoder.JSONDecodeError:
+                except JSONDecodeError:
                     json_value = value
 
                 self._config.update({var_name: json_value})

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,9 @@ include_trailing_comma = true
 
 length_sort = false
 multi_line_output = 3
-not_skip = __init__.py
 order_by_type = true
 sections = FUTURE,STDLIB,THIRDPARTY,OTHER,FIRSTPARTY,LOCALFOLDER
-use_parenthesis = true
+use_parentheses = true
 line_length = 120
 force_grid_wrap = 0
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io import open  # for python 2.7: reading file with encoding
 from os import path
 from setuptools import setup, find_packages
 
@@ -31,6 +32,8 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -1,4 +1,5 @@
 import pytest
+
 from settings_vial import Settings
 
 
@@ -15,8 +16,16 @@ def mock_envfile(tmp_path):
         " it is a certificate value ",
         "===END PUBLIC CERTIFICATE==='",
     )
-    tmp_file.write_text("\n".join(lines))
-    return tmp_file
+    data = "\n".join(lines)
+    try:
+        # Python2 requires unicode, so we need to convert
+        data = data.decode("utf-8")
+    except AttributeError:
+        # Python3 does not have str.decode, but write_text accepts str, so no conversion necessary
+        pass
+
+    tmp_file.write_text(data)
+    return str(tmp_file)
 
 
 class TestEnvfileSettings:

--- a/tests/test_envvars.py
+++ b/tests/test_envvars.py
@@ -1,4 +1,5 @@
 import pytest
+
 from settings_vial import Settings
 
 

--- a/tests/test_override_keys.py
+++ b/tests/test_override_keys.py
@@ -1,4 +1,5 @@
 import pytest
+
 from settings_vial import Settings
 from settings_vial.exceptions import MissingOverrideKeysWarning, NotCallableWarning, UnsupportedSetTypeWarning
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import pytest
+
 from settings_vial import Settings
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 addopts=--tb=short
 
 [tox]
-envlist = lint,isort-check,isort-fix,black-check,black-fix,py36,py37
+envlist = lint,isort-check,isort-fix,black-check,black-fix,py27,py36,py37
 skipsdist = true
 
 [testenv]
@@ -27,12 +27,12 @@ deps = {[lint]deps}
 envdir = {toxworkdir}/lint
 
 [testenv:isort-check]
-commands = isort -rc -c settings_vial tests
+commands = isort -c settings_vial tests
 deps = {[lint]deps}
 envdir = {toxworkdir}/lint
 
 [testenv:isort-fix]
-commands = isort -rc settings_vial tests
+commands = isort settings_vial tests
 deps = {[lint]deps}
 envdir = {toxworkdir}/lint
 


### PR DESCRIPTION
Sadly, this is necessary to migrate a project
from Python2.7 to a new environment so we can
migrate to Python 3.x.